### PR TITLE
Agrego Dockerfile para imagen de quartz

### DIFF
--- a/quartz/Dockerfile
+++ b/quartz/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.7
+
+WORKDIR /app
+COPY ./quartz.py .
+COPY ./run-quartz.sh .
+
+RUN chmod +x /app/run-quartz.sh
+
+RUN apt-get update && \
+    apt-get -y install cron && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install icmplib requests && \
+    pip cache purge
+
+RUN echo "*/5 * * * * root /app/run-quartz.sh" > /etc/cron.d/qartz
+
+RUN mkdir /root/.config
+
+ENV EXECUTION_ENV=DOCKER
+
+CMD ["/app/run-quartz.sh"]

--- a/quartz/quartz.py
+++ b/quartz/quartz.py
@@ -65,6 +65,8 @@ def read_config():
         config['quartz']['isp'] == DEFAULT_ISP
         ):
             LOGGER.error(f'El archivo {CONFIG_FILE} tiene valores dummy.')
+            if os.environ.get('EXECUTION_ENV') == "DOCKER":
+                LOGGER.error(f'Revisá haber pasado las variables de entorno correctas al docker run.')
             sys.exit(1)
     except KeyError:
         LOGGER.error(f'El archivo {CONFIG_FILE} es inválido (está vacío?).')

--- a/quartz/run-quartz.sh
+++ b/quartz/run-quartz.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# En el caso de que se ejecute el cronjob levantamos las variables
+# del contenedor
+xargs -0 -L1 -a /proc/1/environ | grep QUARTZ > /etc/environment
+
+# Usamos las variables de entorno que nos pasan cuando se levanta el contenedor
+# y sino dejamos las default para que rompa el .py
+echo "[quartz]
+api_key = ${QUARTZ_API_KEY:-XXXXXX}
+url = ${QUARTZ_URL:-https://xxxxxxxx}
+isp = ${QUARTZ_ISP:-Nombre del ISP (Fibertel, Telecentro, etc.)} \
+" > /root/.config/quartz.conf
+
+# Corremos el script y lo logueamos just in case
+/usr/local/bin/python /app/quartz.py | /usr/bin/tee -a /app/quartz.log

--- a/quartz/run-quartz.sh
+++ b/quartz/run-quartz.sh
@@ -13,4 +13,4 @@ isp = ${QUARTZ_ISP:-Nombre del ISP (Fibertel, Telecentro, etc.)} \
 " > /root/.config/quartz.conf
 
 # Corremos el script y lo logueamos just in case
-/usr/local/bin/python /app/quartz.py | /usr/bin/tee -a /app/quartz.log
+/usr/local/bin/python /app/quartz.py >> /app/quartz.log 2>&1


### PR DESCRIPTION
Armé un Dockerfile para poder correr quartz en un container.

Traté de hacer modificaciones mínimas al .py para no romper nada a otras personas que puedan estar usandolo, las únicas 2 líneas que agrego no deberían afectar en ejecuciones que ya estén croneadas o a #110. El resto de las features (ponele) las implementé en un wrapper en ✨bash✨.

En el run el container espera las 3 variables de entorno necesarias para quartz. Asumiendo que la imagen se llama `sysarmy/quartz:0.1`, sería:

```console
docker run \
> -e QUARTZ_API_KEY="n0h4yb4cKuP" \
> -e QUARTZ_URL="https://httpbin.org/post" \
> -e QUARTZ_ISP="Telecentro" \
> sysarmy/quartz:0.1
```

Se puede cronear directamente el contenedor, pero también le metí un cron file full latino cada 5 min a la imagen para que si se quiere dejar el container running pisando el `CMD` también se pueda. El único requisito acá es startear cron cuando levantemos el container. Ejemplo de en un docker-compose que queda corriendo:

```yaml
quartz:
    image: sysarmy/quartz:0.1
    environment:
        QUARTZ_API_KEY: "n0h4yb4cKuP"
        QUARTZ_URL: "https://httpbin.org/post"
        QUARTZ_ISP: "Telecentro"
    command: /bin/bash -c "cron start && tail -F /app/quartz.log"
    restart: always
```

Y también va guardando un log en `/app/quartz.log`:

```console
$ tail -5 /app/quartz.log
2022-02-17 01:10:20,848 - quartz - INFO - Datos subidos. Status code: 200
2022-02-17 01:15:45,985 - quartz - ERROR - El archivo /root/.config/quartz.conf tiene valores dummy.
2022-02-17 01:15:45,985 - quartz - ERROR - Revisá haber pasado las variables de entorno correctas al docker run.
2022-02-17 01:20:20,511 - quartz - INFO - Subiendo datos a https://httpbin.org/post.
2022-02-17 01:20:21,338 - quartz - INFO - Datos subidos. Status code: 200
```

---
Probado y funcionando bien en:
```console
$ lsb_release -a
No LSB modules are available.
Distributor ID: Raspbian
Description:    Raspbian GNU/Linux 11 (bullseye)
Release:        11
Codename:       bullseye
```

```console
$ lsb_release -a
LSB Version:    n/a
Distributor ID: ManjaroLinux
Description:    Manjaro Linux
Release:        21.2.3
Codename:       Qonos
```