### PR TITLE
Actualizado el boton de Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to Sysarmy's Disneyland, a place full of broken dreams.
 <img src="https://raw.githubusercontent.com/sysarmy/disneyland/master/misc/images/banner_sysarmy.png">
 
-[![Twitter Follow](https://img.shields.io/twitter/follow/sysarmy?color=1DA1F2&logo=twitter&style=for-the-badge)](https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fgithub.com%2Fsysarmy&screen_name=sysarmy)
+[![Twitter Follow](https://img.shields.io/badge/follow-%40sysarmy-1DA1F2?color=1DA1F2&logo=twitter&style=for-the-badge)](https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fgithub.com%2Fsysarmy&screen_name=sysarmy)
 ![Github Issues](https://img.shields.io/github/issues/sysarmy/disneyland?label=geniales%20ideas%20Pendientes&style=for-the-badge&logoWitdh=50) 
 [<img alt="Calendar button" src="https://img.shields.io/website?down_message=no%20disponible&label=%E2%9E%95%20Calendar%20de%20Sysarmy&style=for-the-badge&up_color=success&up_message=suscribirme&url=https%3A%2F%2Fcalendar.google.com%2Fcalendar%2Fu%2F0%2Fr%3Fcid%3Dc_ntsrg10qsjmfeshhgap8ane1ss%40group.calendar.google.com">](https://calendar.google.com/calendar/u/0/r?cid=c_ntsrg10qsjmfeshhgap8ane1ss@group.calendar.google.com)
 


### PR DESCRIPTION
Cuando Twitter saco el soporte para APIs de 3rd party, rompio el badge